### PR TITLE
Fixes #2: Adds cli pipe support

### DIFF
--- a/validate-csp
+++ b/validate-csp
@@ -33,7 +33,9 @@ OptionParser.new do |opts|
 end.parse!
 
 # Determine whether we are working a URL or a string.
-if ARGV[0].match(/^http/)
+if ARGV.length == 0
+    csp_data = ARGF.read
+elsif ARGV[0].match(/^http/)
   response = Net::HTTP.get_response(URI(ARGV[0]))
   header = (options[:report_only]) ? response['Content-Security-Policy-Report-Only'] : response['Content-Security-Policy']
 


### PR DESCRIPTION
$ cat csp-header
default-src 'none'; script-src 'self' ssl.google-analytics.com 'sha256-xzi4zkCjuC8lZcD2UmnqDG0vurmq12W/XKM5Vd0+MlQ='; style-src 'self' maxcdn.bootstrapcdn.com fonts.googleapis.com; font-src fonts.gstatic.com maxcdn.bootstrapcdn.com; img-src 'self' ssl.google-analytics.com;

$ cat csp-header | ./validate-csp
[ ✔︎ ] 'default-src' is present.
[ ✔︎ ] 'script-src' was found.
[ ✘ ] 'object-src' is not present.
[ ✔︎ ] 'img-src' was found.
[ ✘ ] 'media-src' is not present.
[ ✘ ] 'frame-src' is not present.
[ ✔︎ ] 'font-src' was found.
[ ✘ ] 'frame-ancestors' is not present.
[ ✘ ] 'connect-src' is not present.
[ ✔︎ ] 'style-src' was found.
[ ✻ ] You should consider including a reporting endpoint (using report-uri) so you capture any violations - See http://bit.ly/1C4caYK
